### PR TITLE
Fixed all bootstrap blocks

### DIFF
--- a/src/pages/modules/blockly/blocks/inference/bootstrap_ci_cor.js
+++ b/src/pages/modules/blockly/blocks/inference/bootstrap_ci_cor.js
@@ -24,8 +24,9 @@ Blockly.Blocks['bootstrap_ci_cor'] = {
     this.setInputsInline(false);
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
-    this.setColour(230);
+    this.setColour('230');  // Match color with other inference blocks
     this.setTooltip('Bootstrap confidence interval for correlation using HELPrct data');
+    this.setHelpUrl('https://www.rdocumentation.org/packages/mosaic/topics/resample');
   },
 };
 
@@ -40,11 +41,15 @@ Blockly.Blocks['Gbootstrap_ci_cor'] = {
       .appendField('cor_boot <- do(')
       .appendField(new Blockly.FieldNumber(500, 10, 10000), 'ITERATIONS')
       .appendField(') * cor(')
-      .appendField(new Blockly.FieldTextInput(''), 'VAR1')
+      .appendField(new Blockly.FieldDropdown(quantitative_vars), 'VAR1')
       .appendField(' ~ ')
-      .appendField(new Blockly.FieldTextInput(''), 'VAR2')
+      .appendField(new Blockly.FieldDropdown(quantitative_vars_alt), 'VAR2')
       .appendField(', data = resample(')
-      .appendField(new Blockly.FieldTextInput(''), 'DATASET')
+      .appendField(new Blockly.FieldDropdown([
+        ['HELPrct', 'HELPrct'],
+        ['mosaicData::Whickham', 'mosaicData::Whickham'],
+        ['mosaicData::Births', 'mosaicData::Births']
+      ]), 'DATASET')
       .appendField('))');
     this.appendDummyInput()
       .appendField('confint(cor_boot, level = ')
@@ -54,38 +59,42 @@ Blockly.Blocks['Gbootstrap_ci_cor'] = {
     this.setInputsInline(false);
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
-    this.setColour(230);
-    this.setTooltip('Bootstrap confidence interval for correlation');
+    this.setColour('230');  // Match color
+    this.setTooltip('Bootstrap confidence interval for correlation using selected dataset');
+    this.setHelpUrl('https://www.rdocumentation.org/packages/mosaic/topics/resample');
   },
 };
 
-// Code generator function for both blocks
-function generateBootstrapCICorCode(block) {
+// Generator implementations 
+Blockly.JavaScript['bootstrap_ci_cor'] = function(block) {
   const seed = block.getFieldValue('SEED');
   const var1 = block.getFieldValue('VAR1');
   const var2 = block.getFieldValue('VAR2');
   const iterations = block.getFieldValue('ITERATIONS');
   const confLevel = block.getFieldValue('CONF_LEVEL');
 
-  let code = '';
-
-  if (block.type === 'bootstrap_ci_cor') {
-    code = `# Bootstrap confidence interval for correlation\n`;
-    code += `set.seed(${seed})\n`;
-    code += `cor_boot <- do(${iterations}) * cor(${var1} ~ ${var2}, data = resample(HELPrct))\n`;
-    code += `confint(cor_boot, level = ${confLevel}, method = "quantile")\n`;
-  } else {
-    const dataset = block.getFieldValue('DATASET');
-    code = `# Bootstrap confidence interval for correlation\n`;
-    code += `set.seed(${seed})\n`;
-    code += `cor_boot <- do(${iterations}) * cor(${var1} ~ ${var2}, data = resample(${dataset}))\n`;
-    code += `confint(cor_boot, level = ${confLevel}, method = "quantile")\n`;
-  }
-
+  let code = `set.seed(${seed})\n`;
+  code += `cor_boot <- do(${iterations}) * cor(${var1} ~ ${var2}, data = resample(HELPrct))\n`;
+  code += `confint(cor_boot, level = ${confLevel}, method = "quantile")\n`;
+  
   return code;
-}
+};
 
-Blockly.JavaScript['bootstrap_ci_cor'] = generateBootstrapCICorCode;
-Blockly.JavaScript['Gbootstrap_ci_cor'] = generateBootstrapCICorCode;
+Blockly.JavaScript['Gbootstrap_ci_cor'] = function(block) {
+  const seed = block.getFieldValue('SEED');
+  const var1 = block.getFieldValue('VAR1');
+  const var2 = block.getFieldValue('VAR2');
+  const dataset = block.getFieldValue('DATASET');
+  const iterations = block.getFieldValue('ITERATIONS');
+  const confLevel = block.getFieldValue('CONF_LEVEL');
+
+  let code = `set.seed(${seed})\n`;
+  code += `cor_boot <- do(${iterations}) * cor(${var1} ~ ${var2}, data = resample(${dataset}))\n`;
+  code += `confint(cor_boot, level = ${confLevel}, method = "quantile")\n`;
+  
+  return code;
+};
+
+console.log("Bootstrap CI Correlation block registered:", !!Blockly.JavaScript['bootstrap_ci_cor']);
 
 export default {};

--- a/src/pages/modules/blockly/blocks/inference/bootstrap_ci_diffmean.js
+++ b/src/pages/modules/blockly/blocks/inference/bootstrap_ci_diffmean.js
@@ -1,6 +1,5 @@
 import Blockly from 'blockly';
-import { quantitative_vars } from '../../constants';
-import { categorical_vars_alt } from '../../constants';
+import { quantitative_vars, categorical_vars_alt } from '../../constants';
 
 // HELPrct-specific bootstrap CI for difference in two means block
 Blockly.Blocks['bootstrap_ci_diffmean'] = {
@@ -25,8 +24,9 @@ Blockly.Blocks['bootstrap_ci_diffmean'] = {
     this.setInputsInline(false);
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
-    this.setColour(230);
+    this.setColour('230');  // Match color with other inference blocks
     this.setTooltip('Bootstrap confidence interval for difference in two means using HELPrct data');
+    this.setHelpUrl('https://www.rdocumentation.org/packages/mosaic/topics/resample');
   },
 };
 
@@ -41,11 +41,15 @@ Blockly.Blocks['Gbootstrap_ci_diffmean'] = {
       .appendField('mean_boot <- do(')
       .appendField(new Blockly.FieldNumber(500, 10, 10000), 'ITERATIONS')
       .appendField(') * diffmean(')
-      .appendField(new Blockly.FieldTextInput(''), 'VAR')
+      .appendField(new Blockly.FieldDropdown(quantitative_vars), 'VAR')
       .appendField(' ~ ')
-      .appendField(new Blockly.FieldTextInput(''), 'GROUP')
+      .appendField(new Blockly.FieldDropdown(categorical_vars_alt), 'GROUP')
       .appendField(', data = resample(')
-      .appendField(new Blockly.FieldTextInput(''), 'DATASET')
+      .appendField(new Blockly.FieldDropdown([
+        ['HELPrct', 'HELPrct'],
+        ['mosaicData::Whickham', 'mosaicData::Whickham'],
+        ['mosaicData::Births', 'mosaicData::Births']
+      ]), 'DATASET')
       .appendField('))');
     this.appendDummyInput()
       .appendField('confint(mean_boot, level = ')
@@ -55,38 +59,42 @@ Blockly.Blocks['Gbootstrap_ci_diffmean'] = {
     this.setInputsInline(false);
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
-    this.setColour(230);
-    this.setTooltip('Bootstrap confidence interval for difference in two means');
+    this.setColour('230');  // Match color with other inference blocks
+    this.setTooltip('Bootstrap confidence interval for difference in two means using selected dataset');
+    this.setHelpUrl('https://www.rdocumentation.org/packages/mosaic/topics/resample');
   },
 };
 
-// Code generator function for both blocks
-function generateBootstrapCIDiffMeanCode(block) {
+// Direct generator implementations instead of shared function
+Blockly.JavaScript['bootstrap_ci_diffmean'] = function(block) {
   const seed = block.getFieldValue('SEED');
   const variable = block.getFieldValue('VAR');
   const group = block.getFieldValue('GROUP');
   const iterations = block.getFieldValue('ITERATIONS');
   const confLevel = block.getFieldValue('CONF_LEVEL');
 
-  let code = '';
-
-  if (block.type === 'bootstrap_ci_diffmean') {
-    code = `# Bootstrap confidence interval for difference in two means\n`;
-    code += `set.seed(${seed})\n`;
-    code += `mean_boot <- do(${iterations}) * diffmean(${variable} ~ ${group}, data = resample(HELPrct))\n`;
-    code += `confint(mean_boot, level = ${confLevel}, method = "quantile")\n`;
-  } else {
-    const dataset = block.getFieldValue('DATASET');
-    code = `# Bootstrap confidence interval for difference in two means\n`;
-    code += `set.seed(${seed})\n`;
-    code += `mean_boot <- do(${iterations}) * diffmean(${variable} ~ ${group}, data = resample(${dataset}))\n`;
-    code += `confint(mean_boot, level = ${confLevel}, method = "quantile")\n`;
-  }
-
+  let code = `set.seed(${seed})\n`;
+  code += `mean_boot <- do(${iterations}) * diffmean(${variable} ~ ${group}, data = resample(HELPrct))\n`;
+  code += `confint(mean_boot, level = ${confLevel}, method = "quantile")\n`;
+  
   return code;
-}
+};
 
-Blockly.JavaScript['bootstrap_ci_diffmean'] = generateBootstrapCIDiffMeanCode;
-Blockly.JavaScript['Gbootstrap_ci_diffmean'] = generateBootstrapCIDiffMeanCode;
+Blockly.JavaScript['Gbootstrap_ci_diffmean'] = function(block) {
+  const seed = block.getFieldValue('SEED');
+  const variable = block.getFieldValue('VAR');
+  const group = block.getFieldValue('GROUP');
+  const dataset = block.getFieldValue('DATASET');
+  const iterations = block.getFieldValue('ITERATIONS');
+  const confLevel = block.getFieldValue('CONF_LEVEL');
+
+  let code = `set.seed(${seed})\n`;
+  code += `mean_boot <- do(${iterations}) * diffmean(${variable} ~ ${group}, data = resample(${dataset}))\n`;
+  code += `confint(mean_boot, level = ${confLevel}, method = "quantile")\n`;
+  
+  return code;
+};
+
+console.log("Bootstrap CI Diff Mean block registered:", !!Blockly.JavaScript['bootstrap_ci_diffmean']);
 
 export default {};

--- a/src/pages/modules/blockly/blocks/inference/bootstrap_ci_diffprop.js
+++ b/src/pages/modules/blockly/blocks/inference/bootstrap_ci_diffprop.js
@@ -144,10 +144,11 @@ Blockly.Blocks['bootstrap_ci_diffprop'] = {
     this.setInputsInline(false);
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
-    this.setColour(230);
+    this.setColour('230'); // Updated to match other inference blocks
     this.setTooltip(
       'Bootstrap confidence interval for difference in two proportions using HELPrct data'
     );
+    this.setHelpUrl('https://www.rdocumentation.org/packages/mosaic/topics/resample');
 
     // Explicitly ensure the SUCCESS field has correct default value
     this.setFieldValue('"yes"', 'SUCCESS');
@@ -165,13 +166,27 @@ Blockly.Blocks['Gbootstrap_ci_diffprop'] = {
       .appendField('prop_boot <- do(')
       .appendField(new Blockly.FieldNumber(500, 10, 10000), 'ITERATIONS')
       .appendField(') * diffprop(')
-      .appendField(new Blockly.FieldTextInput(''), 'VAR')
+      .appendField(new Blockly.FieldDropdown(categorical_vars), 'VAR')
       .appendField(' ~ ')
-      .appendField(new Blockly.FieldTextInput(''), 'GROUP')
+      .appendField(new Blockly.FieldDropdown(categorical_vars_alt), 'GROUP')
       .appendField(', data = resample(')
-      .appendField(new Blockly.FieldTextInput(''), 'DATASET')
+      .appendField(new Blockly.FieldDropdown([
+        ['HELPrct', 'HELPrct'],
+        ['mosaicData::Whickham', 'mosaicData::Whickham'],
+        ['mosaicData::Births', 'mosaicData::Births']
+      ]), 'DATASET')
       .appendField('), success = ')
-      .appendField(new Blockly.FieldTextInput('"yes"'), 'SUCCESS')
+      .appendField(new Blockly.FieldDropdown([
+        ['"yes"', '"yes"'],
+        ['"no"', '"no"'],
+        ['"alcohol"', '"alcohol"'],
+        ['"cocaine"', '"cocaine"'],
+        ['"heroin"', '"heroin"'],
+        ['"male"', '"male"'],
+        ['"female"', '"female"'],
+        ['"homeless"', '"homeless"'],
+        ['"housed"', '"housed"'],
+      ]), 'SUCCESS')
       .appendField(')');
     this.appendDummyInput()
       .appendField('confint(prop_boot, level = ')
@@ -181,13 +196,14 @@ Blockly.Blocks['Gbootstrap_ci_diffprop'] = {
     this.setInputsInline(false);
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
-    this.setColour(230);
-    this.setTooltip('Bootstrap confidence interval for difference in two proportions');
+    this.setColour('230'); // Updated to match other inference blocks
+    this.setTooltip('Bootstrap confidence interval for difference in two proportions using selected dataset');
+    this.setHelpUrl('https://www.rdocumentation.org/packages/mosaic/topics/resample');
   },
 };
 
-// Code generator function for both blocks
-function generateBootstrapCIDiffPropCode(block) {
+// Direct generator implementations instead of shared function
+Blockly.JavaScript['bootstrap_ci_diffprop'] = function(block) {
   const seed = block.getFieldValue('SEED');
   const variable = block.getFieldValue('VAR');
   const group = block.getFieldValue('GROUP');
@@ -195,25 +211,29 @@ function generateBootstrapCIDiffPropCode(block) {
   const iterations = block.getFieldValue('ITERATIONS');
   const confLevel = block.getFieldValue('CONF_LEVEL');
 
-  let code = '';
-
-  if (block.type === 'bootstrap_ci_diffprop') {
-    code = `# Bootstrap confidence interval for difference in two proportions\n`;
-    code += `set.seed(${seed})\n`;
-    code += `prop_boot <- do(${iterations}) * diffprop(${variable} ~ ${group}, data = resample(HELPrct), success = ${success})\n`;
-    code += `confint(prop_boot, level = ${confLevel}, method = "quantile")\n`;
-  } else {
-    const dataset = block.getFieldValue('DATASET');
-    code = `# Bootstrap confidence interval for difference in two proportions\n`;
-    code += `set.seed(${seed})\n`;
-    code += `prop_boot <- do(${iterations}) * diffprop(${variable} ~ ${group}, data = resample(${dataset}), success = ${success})\n`;
-    code += `confint(prop_boot, level = ${confLevel}, method = "quantile")\n`;
-  }
-
+  let code = `set.seed(${seed})\n`;
+  code += `prop_boot <- do(${iterations}) * diffprop(${variable} ~ ${group}, data = resample(HELPrct), success = ${success})\n`;
+  code += `confint(prop_boot, level = ${confLevel}, method = "quantile")\n`;
+  
   return code;
-}
+};
 
-Blockly.JavaScript['bootstrap_ci_diffprop'] = generateBootstrapCIDiffPropCode;
-Blockly.JavaScript['Gbootstrap_ci_diffprop'] = generateBootstrapCIDiffPropCode;
+Blockly.JavaScript['Gbootstrap_ci_diffprop'] = function(block) {
+  const seed = block.getFieldValue('SEED');
+  const variable = block.getFieldValue('VAR');
+  const group = block.getFieldValue('GROUP');
+  const dataset = block.getFieldValue('DATASET');
+  const success = block.getFieldValue('SUCCESS');
+  const iterations = block.getFieldValue('ITERATIONS');
+  const confLevel = block.getFieldValue('CONF_LEVEL');
+
+  let code = `set.seed(${seed})\n`;
+  code += `prop_boot <- do(${iterations}) * diffprop(${variable} ~ ${group}, data = resample(${dataset}), success = ${success})\n`;
+  code += `confint(prop_boot, level = ${confLevel}, method = "quantile")\n`;
+  
+  return code;
+};
+
+console.log("Bootstrap CI Diff Prop block registered:", !!Blockly.JavaScript['bootstrap_ci_diffprop']);
 
 export default {};

--- a/src/pages/modules/blockly/blocks/inference/bootstrap_ci_lm.js
+++ b/src/pages/modules/blockly/blocks/inference/bootstrap_ci_lm.js
@@ -24,10 +24,11 @@ Blockly.Blocks['bootstrap_ci_lm'] = {
     this.setInputsInline(false);
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
-    this.setColour(230);
+    this.setColour('230');  // Match color with other inference blocks
     this.setTooltip(
       'Bootstrap confidence interval for slope coefficient in SLR using HELPrct data'
     );
+    this.setHelpUrl('https://www.rdocumentation.org/packages/mosaic/topics/resample');
   },
 };
 
@@ -42,11 +43,15 @@ Blockly.Blocks['Gbootstrap_ci_lm'] = {
       .appendField('lm_boot <- do(')
       .appendField(new Blockly.FieldNumber(500, 10, 10000), 'ITERATIONS')
       .appendField(') * lm(')
-      .appendField(new Blockly.FieldTextInput(''), 'VAR1')
+      .appendField(new Blockly.FieldDropdown(quantitative_vars), 'VAR1')
       .appendField(' ~ ')
-      .appendField(new Blockly.FieldTextInput(''), 'VAR2')
+      .appendField(new Blockly.FieldDropdown(quantitative_vars_alt), 'VAR2')
       .appendField(', data = resample(')
-      .appendField(new Blockly.FieldTextInput(''), 'DATASET')
+      .appendField(new Blockly.FieldDropdown([
+        ['HELPrct', 'HELPrct'],
+        ['mosaicData::Whickham', 'mosaicData::Whickham'],
+        ['mosaicData::Births', 'mosaicData::Births']
+      ]), 'DATASET')
       .appendField('))');
     this.appendDummyInput()
       .appendField('confint(lm_boot, level = ')
@@ -56,38 +61,42 @@ Blockly.Blocks['Gbootstrap_ci_lm'] = {
     this.setInputsInline(false);
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
-    this.setColour(230);
-    this.setTooltip('Bootstrap confidence interval for slope coefficient in SLR');
+    this.setColour('230');  // Match color with other inference blocks
+    this.setTooltip('Bootstrap confidence interval for slope coefficient in SLR using selected dataset');
+    this.setHelpUrl('https://www.rdocumentation.org/packages/mosaic/topics/resample');
   },
 };
 
-// Code generator function for both blocks
-function generateBootstrapCILmCode(block) {
+// Direct generator implementations instead of shared function
+Blockly.JavaScript['bootstrap_ci_lm'] = function(block) {
   const seed = block.getFieldValue('SEED');
   const var1 = block.getFieldValue('VAR1');
   const var2 = block.getFieldValue('VAR2');
   const iterations = block.getFieldValue('ITERATIONS');
   const confLevel = block.getFieldValue('CONF_LEVEL');
 
-  let code = '';
-
-  if (block.type === 'bootstrap_ci_lm') {
-    code = `# Bootstrap confidence interval for slope coefficient in SLR\n`;
-    code += `set.seed(${seed})\n`;
-    code += `lm_boot <- do(${iterations}) * lm(${var1} ~ ${var2}, data = resample(HELPrct))\n`;
-    code += `confint(lm_boot, level = ${confLevel}, method = "quantile")\n`;
-  } else {
-    const dataset = block.getFieldValue('DATASET');
-    code = `# Bootstrap confidence interval for slope coefficient in SLR\n`;
-    code += `set.seed(${seed})\n`;
-    code += `lm_boot <- do(${iterations}) * lm(${var1} ~ ${var2}, data = resample(${dataset}))\n`;
-    code += `confint(lm_boot, level = ${confLevel}, method = "quantile")\n`;
-  }
-
+  let code = `set.seed(${seed})\n`;
+  code += `lm_boot <- do(${iterations}) * lm(${var1} ~ ${var2}, data = resample(HELPrct))\n`;
+  code += `confint(lm_boot, level = ${confLevel}, method = "quantile")\n`;
+  
   return code;
-}
+};
 
-Blockly.JavaScript['bootstrap_ci_lm'] = generateBootstrapCILmCode;
-Blockly.JavaScript['Gbootstrap_ci_lm'] = generateBootstrapCILmCode;
+Blockly.JavaScript['Gbootstrap_ci_lm'] = function(block) {
+  const seed = block.getFieldValue('SEED');
+  const var1 = block.getFieldValue('VAR1');
+  const var2 = block.getFieldValue('VAR2');
+  const dataset = block.getFieldValue('DATASET');
+  const iterations = block.getFieldValue('ITERATIONS');
+  const confLevel = block.getFieldValue('CONF_LEVEL');
+
+  let code = `set.seed(${seed})\n`;
+  code += `lm_boot <- do(${iterations}) * lm(${var1} ~ ${var2}, data = resample(${dataset}))\n`;
+  code += `confint(lm_boot, level = ${confLevel}, method = "quantile")\n`;
+  
+  return code;
+};
+
+console.log("Bootstrap CI LM block registered:", !!Blockly.JavaScript['bootstrap_ci_lm']);
 
 export default {};

--- a/src/pages/modules/blockly/blocks/inference/bootstrap_ci_mlr.js
+++ b/src/pages/modules/blockly/blocks/inference/bootstrap_ci_mlr.js
@@ -26,8 +26,9 @@ Blockly.Blocks['bootstrap_ci_mlr'] = {
     this.setInputsInline(false);
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
-    this.setColour(230);
+    this.setColour('230');  // Match color with other inference blocks
     this.setTooltip('Bootstrap confidence intervals for coefficients in MLR using HELPrct data');
+    this.setHelpUrl('https://www.rdocumentation.org/packages/mosaic/topics/resample');
   },
 };
 
@@ -42,11 +43,17 @@ Blockly.Blocks['Gbootstrap_ci_mlr'] = {
       .appendField('lm_boot <- do(')
       .appendField(new Blockly.FieldNumber(500, 10, 10000), 'ITERATIONS')
       .appendField(') * lm(')
-      .appendField(new Blockly.FieldTextInput(''), 'RESP')
+      .appendField(new Blockly.FieldDropdown(quantitative_vars), 'RESP')
       .appendField(' ~ ')
-      .appendField(new Blockly.FieldTextInput(''), 'MODEL')
+      .appendField(new Blockly.FieldDropdown(quantitative_vars_alt), 'VAR1')
+      .appendField(' + ')
+      .appendField(new Blockly.FieldDropdown(quantitative_vars), 'VAR2')
       .appendField(', data = resample(')
-      .appendField(new Blockly.FieldTextInput(''), 'DATASET')
+      .appendField(new Blockly.FieldDropdown([
+        ['HELPrct', 'HELPrct'],
+        ['mosaicData::Whickham', 'mosaicData::Whickham'],
+        ['mosaicData::Births', 'mosaicData::Births']
+      ]), 'DATASET')
       .appendField('))');
     this.appendDummyInput()
       .appendField('confint(lm_boot, level = ')
@@ -56,43 +63,44 @@ Blockly.Blocks['Gbootstrap_ci_mlr'] = {
     this.setInputsInline(false);
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
-    this.setColour(230);
-    this.setTooltip('Bootstrap confidence intervals for coefficients in MLR');
+    this.setColour('230');  // Match color with other inference blocks
+    this.setTooltip('Bootstrap confidence intervals for coefficients in MLR using selected dataset');
+    this.setHelpUrl('https://www.rdocumentation.org/packages/mosaic/topics/resample');
   },
 };
 
-// Code generator function for both blocks
-function generateBootstrapCIMLRCode(block) {
+// Direct generator implementations instead of shared function
+Blockly.JavaScript['bootstrap_ci_mlr'] = function(block) {
   const seed = block.getFieldValue('SEED');
+  const resp = block.getFieldValue('RESP');
+  const var1 = block.getFieldValue('VAR1');
+  const var2 = block.getFieldValue('VAR2');
   const iterations = block.getFieldValue('ITERATIONS');
   const confLevel = block.getFieldValue('CONF_LEVEL');
 
-  let code = '';
-
-  if (block.type === 'bootstrap_ci_mlr') {
-    const resp = block.getFieldValue('RESP');
-    const var1 = block.getFieldValue('VAR1');
-    const var2 = block.getFieldValue('VAR2');
-
-    code = `# Bootstrap confidence intervals for coefficients in MLR\n`;
-    code += `set.seed(${seed})\n`;
-    code += `lm_boot <- do(${iterations}) * lm(${resp} ~ ${var1} + ${var2}, data = resample(HELPrct))\n`;
-    code += `confint(lm_boot, level = ${confLevel}, method = "quantile")\n`;
-  } else {
-    const resp = block.getFieldValue('RESP');
-    const model = block.getFieldValue('MODEL');
-    const dataset = block.getFieldValue('DATASET');
-
-    code = `# Bootstrap confidence intervals for coefficients in MLR\n`;
-    code += `set.seed(${seed})\n`;
-    code += `lm_boot <- do(${iterations}) * lm(${resp} ~ ${model}, data = resample(${dataset}))\n`;
-    code += `confint(lm_boot, level = ${confLevel}, method = "quantile")\n`;
-  }
-
+  let code = `set.seed(${seed})\n`;
+  code += `lm_boot <- do(${iterations}) * lm(${resp} ~ ${var1} + ${var2}, data = resample(HELPrct))\n`;
+  code += `confint(lm_boot, level = ${confLevel}, method = "quantile")\n`;
+  
   return code;
-}
+};
 
-Blockly.JavaScript['bootstrap_ci_mlr'] = generateBootstrapCIMLRCode;
-Blockly.JavaScript['Gbootstrap_ci_mlr'] = generateBootstrapCIMLRCode;
+Blockly.JavaScript['Gbootstrap_ci_mlr'] = function(block) {
+  const seed = block.getFieldValue('SEED');
+  const resp = block.getFieldValue('RESP');
+  const var1 = block.getFieldValue('VAR1');
+  const var2 = block.getFieldValue('VAR2');
+  const dataset = block.getFieldValue('DATASET');
+  const iterations = block.getFieldValue('ITERATIONS');
+  const confLevel = block.getFieldValue('CONF_LEVEL');
+
+  let code = `set.seed(${seed})\n`;
+  code += `lm_boot <- do(${iterations}) * lm(${resp} ~ ${var1} + ${var2}, data = resample(${dataset}))\n`;
+  code += `confint(lm_boot, level = ${confLevel}, method = "quantile")\n`;
+  
+  return code;
+};
+
+console.log("Bootstrap CI MLR block registered:", !!Blockly.JavaScript['bootstrap_ci_mlr']);
 
 export default {};

--- a/src/pages/modules/blockly/blocks/inference/bootstrap_ci_paired.js
+++ b/src/pages/modules/blockly/blocks/inference/bootstrap_ci_paired.js
@@ -26,8 +26,9 @@ Blockly.Blocks['bootstrap_ci_paired'] = {
     this.setInputsInline(false);
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
-    this.setColour(230);
+    this.setColour('230');  // Match color with other inference blocks
     this.setTooltip('Bootstrap confidence interval for paired mean difference using HELPrct data');
+    this.setHelpUrl('https://www.rdocumentation.org/packages/mosaic/topics/resample');
   },
 };
 
@@ -40,19 +41,31 @@ Blockly.Blocks['Gbootstrap_ci_paired'] = {
       .appendField(')');
     this.appendDummyInput()
       .appendField('')
-      .appendField(new Blockly.FieldTextInput(''), 'DATASET')
+      .appendField(new Blockly.FieldDropdown([
+        ['HELPrct', 'HELPrct'],
+        ['mosaicData::Whickham', 'mosaicData::Whickham'],
+        ['mosaicData::Births', 'mosaicData::Births']
+      ]), 'DATASET')
       .appendField(' <- mutate(')
-      .appendField(new Blockly.FieldTextInput(''), 'ORIG_DATASET')
+      .appendField(new Blockly.FieldDropdown([
+        ['HELPrct', 'HELPrct'],
+        ['mosaicData::Whickham', 'mosaicData::Whickham'],
+        ['mosaicData::Births', 'mosaicData::Births']
+      ]), 'ORIG_DATASET')
       .appendField(', pair.diff = ')
-      .appendField(new Blockly.FieldTextInput(''), 'POST_VAR')
+      .appendField(new Blockly.FieldDropdown(quantitative_vars), 'POST_VAR')
       .appendField(' - ')
-      .appendField(new Blockly.FieldTextInput(''), 'PRE_VAR')
+      .appendField(new Blockly.FieldDropdown(quantitative_vars), 'PRE_VAR')
       .appendField(')');
     this.appendDummyInput()
       .appendField('mean_boot <- do(')
       .appendField(new Blockly.FieldNumber(500, 10, 10000), 'ITERATIONS')
       .appendField(') * mean(~ pair.diff, data = resample(')
-      .appendField(new Blockly.FieldTextInput(''), 'RESAMPLE_DATASET')
+      .appendField(new Blockly.FieldDropdown([
+        ['HELPrct', 'HELPrct'],
+        ['mosaicData::Whickham', 'mosaicData::Whickham'],
+        ['mosaicData::Births', 'mosaicData::Births']
+      ]), 'RESAMPLE_DATASET')
       .appendField('))');
     this.appendDummyInput()
       .appendField('confint(mean_boot, level = ')
@@ -62,8 +75,9 @@ Blockly.Blocks['Gbootstrap_ci_paired'] = {
     this.setInputsInline(false);
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
-    this.setColour(230);
-    this.setTooltip('Bootstrap confidence interval for paired mean difference');
+    this.setColour('230');  // Match color with other inference blocks
+    this.setTooltip('Bootstrap confidence interval for paired mean difference using selected dataset');
+    this.setHelpUrl('https://www.rdocumentation.org/packages/mosaic/topics/resample');
 
     // Automatically update fields when dataset changes
     this.setOnChange(function (changeEvent) {
@@ -85,41 +99,40 @@ Blockly.Blocks['Gbootstrap_ci_paired'] = {
   },
 };
 
-// Code generator function for both blocks
-function generateBootstrapCIPairedCode(block) {
+// Separate generator functions for each block
+Blockly.JavaScript['bootstrap_ci_paired'] = function(block) {
   const seed = block.getFieldValue('SEED');
+  const preVar = block.getFieldValue('PRE_VAR');
+  const postVar = block.getFieldValue('POST_VAR');
   const iterations = block.getFieldValue('ITERATIONS');
   const confLevel = block.getFieldValue('CONF_LEVEL');
 
-  let code = '';
-
-  if (block.type === 'bootstrap_ci_paired') {
-    const preVar = block.getFieldValue('PRE_VAR');
-    const postVar = block.getFieldValue('POST_VAR');
-
-    code = `# Bootstrap confidence interval for paired mean difference\n`;
-    code += `HELPrct <- mutate(HELPrct, pair.diff = ${postVar} - ${preVar})\n`;
-    code += `set.seed(${seed})\n`;
-    code += `mean_boot <- do(${iterations}) * mean(~ pair.diff, data = resample(HELPrct))\n`;
-    code += `confint(mean_boot, level = ${confLevel}, method = "quantile")\n`;
-  } else {
-    const dataset = block.getFieldValue('DATASET');
-    const origDataset = block.getFieldValue('ORIG_DATASET');
-    const preVar = block.getFieldValue('PRE_VAR');
-    const postVar = block.getFieldValue('POST_VAR');
-    const resampleDataset = block.getFieldValue('RESAMPLE_DATASET');
-
-    code = `# Bootstrap confidence interval for paired mean difference\n`;
-    code += `${dataset} <- mutate(${origDataset}, pair.diff = ${postVar} - ${preVar})\n`;
-    code += `set.seed(${seed})\n`;
-    code += `mean_boot <- do(${iterations}) * mean(~ pair.diff, data = resample(${resampleDataset}))\n`;
-    code += `confint(mean_boot, level = ${confLevel}, method = "quantile")\n`;
-  }
-
+  let code = `set.seed(${seed})\n`;
+  code += `HELPrct <- mutate(HELPrct, pair.diff = ${postVar} - ${preVar})\n`;
+  code += `mean_boot <- do(${iterations}) * mean(~ pair.diff, data = resample(HELPrct))\n`;
+  code += `confint(mean_boot, level = ${confLevel}, method = "quantile")\n`;
+  
   return code;
-}
+};
 
-Blockly.JavaScript['bootstrap_ci_paired'] = generateBootstrapCIPairedCode;
-Blockly.JavaScript['Gbootstrap_ci_paired'] = generateBootstrapCIPairedCode;
+Blockly.JavaScript['Gbootstrap_ci_paired'] = function(block) {
+  const seed = block.getFieldValue('SEED');
+  const dataset = block.getFieldValue('DATASET');
+  const origDataset = block.getFieldValue('ORIG_DATASET');
+  const preVar = block.getFieldValue('PRE_VAR');
+  const postVar = block.getFieldValue('POST_VAR');
+  const resampleDataset = block.getFieldValue('RESAMPLE_DATASET');
+  const iterations = block.getFieldValue('ITERATIONS');
+  const confLevel = block.getFieldValue('CONF_LEVEL');
+
+  let code = `set.seed(${seed})\n`;
+  code += `${dataset} <- mutate(${origDataset}, pair.diff = ${postVar} - ${preVar})\n`;
+  code += `mean_boot <- do(${iterations}) * mean(~ pair.diff, data = resample(${resampleDataset}))\n`;
+  code += `confint(mean_boot, level = ${confLevel}, method = "quantile")\n`;
+  
+  return code;
+};
+
+console.log("Bootstrap CI Paired block registered:", !!Blockly.JavaScript['bootstrap_ci_paired']);
 
 export default {};

--- a/src/pages/modules/blockly/blocks/inference/bootstrap_test_mean.js
+++ b/src/pages/modules/blockly/blocks/inference/bootstrap_test_mean.js
@@ -41,8 +41,9 @@ Blockly.Blocks['bootstrap_test_mean'] = {
     this.setInputsInline(false);
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
-    this.setColour(230);
+    this.setColour('230');  // Match color with other inference blocks
     this.setTooltip('Bootstrap test for one mean using HELPrct data');
+    this.setHelpUrl('https://www.rdocumentation.org/packages/mosaic/topics/resample');
   },
 };
 
@@ -55,29 +56,45 @@ Blockly.Blocks['Gbootstrap_test_mean'] = {
       .appendField(')');
     this.appendDummyInput()
       .appendField('observed_mean <- mean(~')
-      .appendField(new Blockly.FieldTextInput(''), 'VAR')
+      .appendField(new Blockly.FieldDropdown(quantitative_vars), 'VAR')
       .appendField(', data=')
-      .appendField(new Blockly.FieldTextInput(''), 'DATASET')
+      .appendField(new Blockly.FieldDropdown([
+        ['HELPrct', 'HELPrct'],
+        ['mosaicData::Whickham', 'mosaicData::Whickham'],
+        ['mosaicData::Births', 'mosaicData::Births']
+      ]), 'DATASET')
       .appendField(')');
     this.appendDummyInput()
       .appendField('')
-      .appendField(new Blockly.FieldTextInput(''), 'DATASET')
+      .appendField(new Blockly.FieldDropdown([
+        ['HELPrct', 'HELPrct'],
+        ['mosaicData::Whickham', 'mosaicData::Whickham'],
+        ['mosaicData::Births', 'mosaicData::Births']
+      ]), 'SHIFTED_DATASET')
       .appendField('_shifted <- mutate(')
-      .appendField(new Blockly.FieldTextInput(''), 'DATASET')
+      .appendField(new Blockly.FieldDropdown([
+        ['HELPrct', 'HELPrct'],
+        ['mosaicData::Whickham', 'mosaicData::Whickham'],
+        ['mosaicData::Births', 'mosaicData::Births']
+      ]), 'ORIG_DATASET')
       .appendField(', new_')
-      .appendField(new Blockly.FieldTextInput(''), 'VAR')
+      .appendField(new Blockly.FieldDropdown(quantitative_vars), 'VAR2')
       .appendField(' = ')
-      .appendField(new Blockly.FieldTextInput(''), 'VAR')
+      .appendField(new Blockly.FieldDropdown(quantitative_vars), 'VAR3')
       .appendField(' - observed_mean + ')
       .appendField(new Blockly.FieldNumber(0, -999999, 999999), 'NULL_VALUE')
       .appendField(')');
     this.appendDummyInput()
       .appendField('sim_null <- do(')
-      .appendField(new Blockly.FieldNumber(5000, 100, 10000), 'ITERATIONS')
+      .appendField(new Blockly.FieldNumber(500, 10, 10000), 'ITERATIONS')
       .appendField(') * mean(~ new_')
-      .appendField(new Blockly.FieldTextInput(''), 'VAR')
+      .appendField(new Blockly.FieldDropdown(quantitative_vars), 'VAR4')
       .appendField(', data = resample(')
-      .appendField(new Blockly.FieldTextInput(''), 'DATASET')
+      .appendField(new Blockly.FieldDropdown([
+        ['HELPrct', 'HELPrct'],
+        ['mosaicData::Whickham', 'mosaicData::Whickham'],
+        ['mosaicData::Births', 'mosaicData::Births']
+      ]), 'RESAMPLE_DATASET')
       .appendField('_shifted))');
     this.appendDummyInput()
       .appendField('prop(~ (')
@@ -94,43 +111,96 @@ Blockly.Blocks['Gbootstrap_test_mean'] = {
     this.setInputsInline(false);
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
-    this.setColour(230);
-    this.setTooltip('Bootstrap test for one mean');
+    this.setColour('230');  // Match color with other inference blocks
+    this.setTooltip('Bootstrap test for one mean using selected dataset');
+    this.setHelpUrl('https://www.rdocumentation.org/packages/mosaic/topics/resample');
+
+    // Automatically update related fields when dataset changes
+    this.setOnChange(function (changeEvent) {
+      if (
+        changeEvent.name === 'DATASET' ||
+        (changeEvent.element === 'field' && changeEvent.name === 'DATASET')
+      ) {
+        const datasetValue = this.getFieldValue('DATASET');
+        this.setFieldValue(datasetValue, 'SHIFTED_DATASET');
+        this.setFieldValue(datasetValue, 'ORIG_DATASET');
+        this.setFieldValue(datasetValue, 'RESAMPLE_DATASET');
+      }
+      if (
+        changeEvent.name === 'VAR' ||
+        (changeEvent.element === 'field' && changeEvent.name === 'VAR')
+      ) {
+        const varValue = this.getFieldValue('VAR');
+        this.setFieldValue(varValue, 'VAR2');
+        this.setFieldValue(varValue, 'VAR3');
+        this.setFieldValue(varValue, 'VAR4');
+      }
+    });
   },
 };
 
-// Code generator function for both blocks
-function generateBootstrapTestMeanCode(block) {
+// Separate generator functions for each block
+Blockly.JavaScript['bootstrap_test_mean'] = function(block) {
   const seed = block.getFieldValue('SEED');
   const variable = block.getFieldValue('VAR');
-  // Changed from block.getType() to block.type
-  const dataset = block.type === 'bootstrap_test_mean' ? 'HELPrct' : block.getFieldValue('DATASET');
   const nullValue = block.getFieldValue('NULL_VALUE');
-  const sampleSize = block.getFieldValue('SAMPLE_SIZE');
   const alternative = block.getFieldValue('ALTERNATIVE');
   const iterations = block.getFieldValue('ITERATIONS');
 
-  let code = `# Get the observed sample mean\nobserved_mean <- mean(~${variable}, data=${dataset})\n\n`;
-  code += `# Create shifted data for null hypothesis\n${dataset}_shifted <- mutate(${dataset}, new_${variable} = ${variable} - observed_mean + ${nullValue})\n\n`;
-  code += `set.seed(${seed})\n`;
-  code += `sim_null <- do(${iterations}) * mean(~ new_${variable}, data = resample(${dataset}_shifted))\n\n`;
+  let code = `set.seed(${seed})\n`;
+  code += `observed_mean <- mean(~${variable}, data=HELPrct)\n`;
+  code += `HELPrct_shifted <- mutate(HELPrct, new_${variable} = ${variable} - observed_mean + ${nullValue})\n`;
+  code += `sim_null <- do(${iterations}) * mean(~ new_${variable}, data = resample(HELPrct_shifted))\n`;
 
   switch (alternative) {
     case 'less':
-      code += `prop(~ (mean <= observed_mean), data = sim_null) ## P-value for less than ##\n`;
+      code += `prop(~ (mean <= observed_mean), data = sim_null)\n`;
       break;
     case 'greater':
-      code += `prop(~ (mean >= observed_mean), data = sim_null) ## P-value for greater than ##\n`;
+      code += `prop(~ (mean >= observed_mean), data = sim_null)\n`;
       break;
     case 'two.sided':
-      code += `prop(~ (abs(mean-${nullValue}) >= abs(observed_mean-${nullValue})), data = sim_null) ## P-value for not equal ##\n`;
+      code += `prop(~ (abs(mean-${nullValue}) >= abs(observed_mean-${nullValue})), data = sim_null)\n`;
       break;
   }
-
+  
   return code;
-}
+};
 
-Blockly.JavaScript['bootstrap_test_mean'] = generateBootstrapTestMeanCode;
-Blockly.JavaScript['Gbootstrap_test_mean'] = generateBootstrapTestMeanCode;
+Blockly.JavaScript['Gbootstrap_test_mean'] = function(block) {
+  const seed = block.getFieldValue('SEED');
+  const variable = block.getFieldValue('VAR');
+  const dataset = block.getFieldValue('DATASET');
+  const shiftedDataset = block.getFieldValue('SHIFTED_DATASET');
+  const origDataset = block.getFieldValue('ORIG_DATASET');
+  const var2 = block.getFieldValue('VAR2');
+  const var3 = block.getFieldValue('VAR3');
+  const var4 = block.getFieldValue('VAR4');
+  const resampleDataset = block.getFieldValue('RESAMPLE_DATASET');
+  const nullValue = block.getFieldValue('NULL_VALUE');
+  const alternative = block.getFieldValue('ALTERNATIVE');
+  const iterations = block.getFieldValue('ITERATIONS');
+
+  let code = `set.seed(${seed})\n`;
+  code += `observed_mean <- mean(~${variable}, data=${dataset})\n`;
+  code += `${shiftedDataset}_shifted <- mutate(${origDataset}, new_${var2} = ${var3} - observed_mean + ${nullValue})\n`;
+  code += `sim_null <- do(${iterations}) * mean(~ new_${var4}, data = resample(${resampleDataset}_shifted))\n`;
+
+  switch (alternative) {
+    case 'less':
+      code += `prop(~ (mean <= observed_mean), data = sim_null)\n`;
+      break;
+    case 'greater':
+      code += `prop(~ (mean >= observed_mean), data = sim_null)\n`;
+      break;
+    case 'two.sided':
+      code += `prop(~ (abs(mean-${nullValue}) >= abs(observed_mean-${nullValue})), data = sim_null)\n`;
+      break;
+  }
+  
+  return code;
+};
+
+console.log("Bootstrap Test Mean block registered:", !!Blockly.JavaScript['bootstrap_test_mean']);
 
 export default {};

--- a/src/pages/modules/blockly/blocks/inference/bootstrap_test_paired.js
+++ b/src/pages/modules/blockly/blocks/inference/bootstrap_test_paired.js
@@ -35,8 +35,9 @@ Blockly.Blocks['bootstrap_test_paired'] = {
     this.setInputsInline(false);
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
-    this.setColour(230);
+    this.setColour('230');  // Match color with other inference blocks
     this.setTooltip('Bootstrap test for paired mean difference using HELPrct data');
+    this.setHelpUrl('https://www.rdocumentation.org/packages/mosaic/topics/resample');
   },
 };
 
@@ -49,29 +50,53 @@ Blockly.Blocks['Gbootstrap_test_paired'] = {
       .appendField(')');
     this.appendDummyInput()
       .appendField('')
-      .appendField(new Blockly.FieldTextInput(''), 'DATASET')
+      .appendField(new Blockly.FieldDropdown([
+        ['HELPrct', 'HELPrct'],
+        ['mosaicData::Whickham', 'mosaicData::Whickham'],
+        ['mosaicData::Births', 'mosaicData::Births']
+      ]), 'DATASET')
       .appendField(' <- mutate(')
-      .appendField(new Blockly.FieldTextInput(''), 'ORIG_DATASET')
+      .appendField(new Blockly.FieldDropdown([
+        ['HELPrct', 'HELPrct'],
+        ['mosaicData::Whickham', 'mosaicData::Whickham'],
+        ['mosaicData::Births', 'mosaicData::Births']
+      ]), 'ORIG_DATASET')
       .appendField(', pair.diff = ')
-      .appendField(new Blockly.FieldTextInput(''), 'POST_VAR')
+      .appendField(new Blockly.FieldDropdown(quantitative_vars), 'POST_VAR')
       .appendField(' - ')
-      .appendField(new Blockly.FieldTextInput(''), 'PRE_VAR')
+      .appendField(new Blockly.FieldDropdown(quantitative_vars), 'PRE_VAR')
       .appendField(')');
     this.appendDummyInput()
       .appendField('bar_d <- mean(~ pair.diff, data = ')
-      .appendField(new Blockly.FieldTextInput(''), 'MEAN_DATASET')
+      .appendField(new Blockly.FieldDropdown([
+        ['HELPrct', 'HELPrct'],
+        ['mosaicData::Whickham', 'mosaicData::Whickham'],
+        ['mosaicData::Births', 'mosaicData::Births']
+      ]), 'MEAN_DATASET')
       .appendField(')');
     this.appendDummyInput()
       .appendField('')
-      .appendField(new Blockly.FieldTextInput(''), 'DATASET2')
+      .appendField(new Blockly.FieldDropdown([
+        ['HELPrct', 'HELPrct'],
+        ['mosaicData::Whickham', 'mosaicData::Whickham'],
+        ['mosaicData::Births', 'mosaicData::Births']
+      ]), 'DATASET2')
       .appendField(' <- mutate(')
-      .appendField(new Blockly.FieldTextInput(''), 'DATASET3')
+      .appendField(new Blockly.FieldDropdown([
+        ['HELPrct', 'HELPrct'],
+        ['mosaicData::Whickham', 'mosaicData::Whickham'],
+        ['mosaicData::Births', 'mosaicData::Births']
+      ]), 'DATASET3')
       .appendField(', new_diff = pair.diff - bar_d)');
     this.appendDummyInput()
       .appendField('sim_null <- do(')
       .appendField(new Blockly.FieldNumber(500, 10, 10000), 'ITERATIONS')
       .appendField(') * mean(~ new_diff, data = resample(')
-      .appendField(new Blockly.FieldTextInput(''), 'RESAMPLE_DATASET')
+      .appendField(new Blockly.FieldDropdown([
+        ['HELPrct', 'HELPrct'],
+        ['mosaicData::Whickham', 'mosaicData::Whickham'],
+        ['mosaicData::Births', 'mosaicData::Births']
+      ]), 'RESAMPLE_DATASET')
       .appendField('))');
     this.appendDummyInput()
       .appendField('prop(~ (')
@@ -88,8 +113,9 @@ Blockly.Blocks['Gbootstrap_test_paired'] = {
     this.setInputsInline(false);
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
-    this.setColour(230);
-    this.setTooltip('Bootstrap test for paired mean difference');
+    this.setColour('230');  // Match color with other inference blocks
+    this.setTooltip('Bootstrap test for paired mean difference using selected dataset');
+    this.setHelpUrl('https://www.rdocumentation.org/packages/mosaic/topics/resample');
 
     // Automatically update fields when dataset changes
     this.setOnChange(function (changeEvent) {
@@ -114,70 +140,69 @@ Blockly.Blocks['Gbootstrap_test_paired'] = {
   },
 };
 
-// Code generator function for both blocks
-function generateBootstrapTestPairedCode(block) {
+// Separate generator functions for each block
+Blockly.JavaScript['bootstrap_test_paired'] = function(block) {
   const seed = block.getFieldValue('SEED');
+  const preVar = block.getFieldValue('PRE_VAR');
+  const postVar = block.getFieldValue('POST_VAR');
   const iterations = block.getFieldValue('ITERATIONS');
   const alternative = block.getFieldValue('ALTERNATIVE');
 
-  let code = '';
+  let code = `set.seed(${seed})\n`;
+  code += `HELPrct <- mutate(HELPrct, pair.diff = ${postVar} - ${preVar})\n`;
+  code += `bar_d <- mean(~ pair.diff, data = HELPrct)\n`;
+  code += `HELPrct <- mutate(HELPrct, new_diff = pair.diff - bar_d)\n`;
+  code += `sim_null <- do(${iterations}) * mean(~ new_diff, data = resample(HELPrct))\n`;
 
-  if (block.type === 'bootstrap_test_paired') {
-    const preVar = block.getFieldValue('PRE_VAR');
-    const postVar = block.getFieldValue('POST_VAR');
-
-    code = `# Bootstrap test for paired mean difference\n`;
-    code += `HELPrct <- mutate(HELPrct, pair.diff = ${postVar} - ${preVar})\n`;
-    code += `bar_d <- mean(~ pair.diff, data = HELPrct)\n`;
-    code += `HELPrct <- mutate(HELPrct, new_diff = pair.diff - bar_d)\n`;
-    code += `set.seed(${seed})\n`;
-    code += `sim_null <- do(${iterations}) * mean(~ new_diff, data = resample(HELPrct))\n\n`;
-
-    switch (alternative) {
-      case 'less':
-        code += `prop(~ (mean <= bar_d), data = sim_null) ## P-value for less than ##\n`;
-        break;
-      case 'greater':
-        code += `prop(~ (mean >= bar_d), data = sim_null) ## P-value for greater than ##\n`;
-        break;
-      case 'two.sided':
-        code += `prop(~ (abs(mean) >= abs(bar_d)), data = sim_null) ## P-value for not equal ##\n`;
-        break;
-    }
-  } else {
-    const dataset = block.getFieldValue('DATASET');
-    const origDataset = block.getFieldValue('ORIG_DATASET');
-    const preVar = block.getFieldValue('PRE_VAR');
-    const postVar = block.getFieldValue('POST_VAR');
-    const meanDataset = block.getFieldValue('MEAN_DATASET');
-    const dataset2 = block.getFieldValue('DATASET2');
-    const dataset3 = block.getFieldValue('DATASET3');
-    const resampleDataset = block.getFieldValue('RESAMPLE_DATASET');
-
-    code = `# Bootstrap test for paired mean difference\n`;
-    code += `${dataset} <- mutate(${origDataset}, pair.diff = ${postVar} - ${preVar})\n`;
-    code += `bar_d <- mean(~ pair.diff, data = ${meanDataset})\n`;
-    code += `${dataset2} <- mutate(${dataset3}, new_diff = pair.diff - bar_d)\n`;
-    code += `set.seed(${seed})\n`;
-    code += `sim_null <- do(${iterations}) * mean(~ new_diff, data = resample(${resampleDataset}))\n\n`;
-
-    switch (alternative) {
-      case 'less':
-        code += `prop(~ (mean <= bar_d), data = sim_null) ## P-value for less than ##\n`;
-        break;
-      case 'greater':
-        code += `prop(~ (mean >= bar_d), data = sim_null) ## P-value for greater than ##\n`;
-        break;
-      case 'two.sided':
-        code += `prop(~ (abs(mean) >= abs(bar_d)), data = sim_null) ## P-value for not equal ##\n`;
-        break;
-    }
+  switch (alternative) {
+    case 'less':
+      code += `prop(~ (mean <= bar_d), data = sim_null)\n`;
+      break;
+    case 'greater':
+      code += `prop(~ (mean >= bar_d), data = sim_null)\n`;
+      break;
+    case 'two.sided':
+      code += `prop(~ (abs(mean) >= abs(bar_d)), data = sim_null)\n`;
+      break;
   }
-
+  
   return code;
-}
+};
 
-Blockly.JavaScript['bootstrap_test_paired'] = generateBootstrapTestPairedCode;
-Blockly.JavaScript['Gbootstrap_test_paired'] = generateBootstrapTestPairedCode;
+Blockly.JavaScript['Gbootstrap_test_paired'] = function(block) {
+  const seed = block.getFieldValue('SEED');
+  const dataset = block.getFieldValue('DATASET');
+  const origDataset = block.getFieldValue('ORIG_DATASET');
+  const preVar = block.getFieldValue('PRE_VAR');
+  const postVar = block.getFieldValue('POST_VAR');
+  const meanDataset = block.getFieldValue('MEAN_DATASET');
+  const dataset2 = block.getFieldValue('DATASET2');
+  const dataset3 = block.getFieldValue('DATASET3');
+  const resampleDataset = block.getFieldValue('RESAMPLE_DATASET');
+  const iterations = block.getFieldValue('ITERATIONS');
+  const alternative = block.getFieldValue('ALTERNATIVE');
+
+  let code = `set.seed(${seed})\n`;
+  code += `${dataset} <- mutate(${origDataset}, pair.diff = ${postVar} - ${preVar})\n`;
+  code += `bar_d <- mean(~ pair.diff, data = ${meanDataset})\n`;
+  code += `${dataset2} <- mutate(${dataset3}, new_diff = pair.diff - bar_d)\n`;
+  code += `sim_null <- do(${iterations}) * mean(~ new_diff, data = resample(${resampleDataset}))\n`;
+
+  switch (alternative) {
+    case 'less':
+      code += `prop(~ (mean <= bar_d), data = sim_null)\n`;
+      break;
+    case 'greater':
+      code += `prop(~ (mean >= bar_d), data = sim_null)\n`;
+      break;
+    case 'two.sided':
+      code += `prop(~ (abs(mean) >= abs(bar_d)), data = sim_null)\n`;
+      break;
+  }
+  
+  return code;
+};
+
+console.log("Bootstrap Test Paired block registered:", !!Blockly.JavaScript['bootstrap_test_paired']);
 
 export default {};


### PR DESCRIPTION
This pull request includes several changes to the Blockly blocks for generating bootstrap confidence intervals in various statistical contexts. The changes primarily focus on improving the user interface by replacing text inputs with dropdowns, updating tooltips, adding help URLs, and ensuring consistency in block colors.

### Improvements to Blockly Blocks:

* `src/pages/modules/blockly/blocks/inference/bootstrap_ci_cor.js`:
  - Updated color to match other inference blocks and added a help URL.
  - Replaced text inputs with dropdowns for selecting variables and datasets.
  - Modified tooltips and added a help URL.

* `src/pages/modules/blockly/blocks/inference/bootstrap_ci_diffmean.js`:
  - Updated color to match other inference blocks and added a help URL.
  - Replaced text inputs with dropdowns for selecting variables and datasets.
  - Modified tooltips and added a help URL.

* `src/pages/modules/blockly/blocks/inference/bootstrap_ci_diffprop.js`:
  - Updated color to match other inference blocks and added a help URL.
  - Replaced text inputs with dropdowns for selecting variables, groups, datasets, and success criteria.
  - Modified tooltips and added a help URL.

* `src/pages/modules/blockly/blocks/inference/bootstrap_ci_lm.js`:
  - Updated color to match other inference blocks and added a help URL.
  - Replaced text inputs with dropdowns for selecting variables and datasets.
  - Modified tooltips and added a help URL.

* `src/pages/modules/blockly/blocks/inference/bootstrap_ci_mean.js`:
  - Updated color to match other inference blocks and added a help URL.
  - Replaced text inputs with dropdowns for selecting variables and datasets.
  - Modified tooltips and added a help URL.