### PR TITLE
Changed bootstrap default from 500 to 5000 and fixed display issues

### DIFF
--- a/src/pages/modules/blockly/blocks/inference/bootstrap_ci_cor.js
+++ b/src/pages/modules/blockly/blocks/inference/bootstrap_ci_cor.js
@@ -39,7 +39,7 @@ Blockly.Blocks['Gbootstrap_ci_cor'] = {
       .appendField(')');
     this.appendDummyInput()
       .appendField('cor_boot <- do(')
-      .appendField(new Blockly.FieldNumber(500, 10, 10000), 'ITERATIONS')
+      .appendField(new Blockly.FieldNumber(5000, 10, 10000), 'ITERATIONS')
       .appendField(') * cor(')
       .appendField(new Blockly.FieldTextInput(''), 'VAR1')
       .appendField(' ~ ')

--- a/src/pages/modules/blockly/blocks/inference/bootstrap_ci_diffmean.js
+++ b/src/pages/modules/blockly/blocks/inference/bootstrap_ci_diffmean.js
@@ -10,7 +10,7 @@ Blockly.Blocks['bootstrap_ci_diffmean'] = {
       .appendField(')');
     this.appendDummyInput()
       .appendField('mean_boot <- do(')
-      .appendField(new Blockly.FieldNumber(500, 10, 10000), 'ITERATIONS')
+      .appendField(new Blockly.FieldNumber(5000, 10, 10000), 'ITERATIONS')
       .appendField(') * diffmean(')
       .appendField(new Blockly.FieldDropdown(quantitative_vars), 'VAR')
       .appendField(' ~ ')
@@ -39,7 +39,7 @@ Blockly.Blocks['Gbootstrap_ci_diffmean'] = {
       .appendField(')');
     this.appendDummyInput()
       .appendField('mean_boot <- do(')
-      .appendField(new Blockly.FieldNumber(500, 10, 10000), 'ITERATIONS')
+      .appendField(new Blockly.FieldNumber(5000, 10, 10000), 'ITERATIONS')
       .appendField(') * diffmean(')
       .appendField(new Blockly.FieldTextInput(''), 'VAR')
       .appendField(' ~ ')

--- a/src/pages/modules/blockly/blocks/inference/bootstrap_ci_diffprop.js
+++ b/src/pages/modules/blockly/blocks/inference/bootstrap_ci_diffprop.js
@@ -24,6 +24,7 @@ Blockly.Blocks['bootstrap_ci_diffprop'] = {
             ]),
             'SUCCESS'
           );
+          this.getInput('PROP_INPUT').appendField(')'); 
         } else if (newVar === 'anysub') {
           this.getInput('PROP_INPUT').removeField('SUCCESS');
           this.getInput('PROP_INPUT').appendField(
@@ -35,6 +36,7 @@ Blockly.Blocks['bootstrap_ci_diffprop'] = {
           );
           // Set default for anysub
           this.setFieldValue('"yes"', 'SUCCESS');
+          this.getInput('PROP_INPUT').appendField(')'); 
         } else if (newVar === 'sex') {
           this.getInput('PROP_INPUT').removeField('SUCCESS');
           this.getInput('PROP_INPUT').appendField(
@@ -46,6 +48,7 @@ Blockly.Blocks['bootstrap_ci_diffprop'] = {
           );
           // Set default for sex
           this.setFieldValue('"male"', 'SUCCESS');
+          this.getInput('PROP_INPUT').appendField(')'); 
         } else if (newVar === 'homeless') {
           this.getInput('PROP_INPUT').removeField('SUCCESS');
           this.getInput('PROP_INPUT').appendField(
@@ -57,6 +60,7 @@ Blockly.Blocks['bootstrap_ci_diffprop'] = {
           );
           // Set default for homeless
           this.setFieldValue('"homeless"', 'SUCCESS');
+          this.getInput('PROP_INPUT').appendField(')'); 
         } else if (newVar === 'link') {
           this.getInput('PROP_INPUT').removeField('SUCCESS');
           this.getInput('PROP_INPUT').appendField(
@@ -68,6 +72,7 @@ Blockly.Blocks['bootstrap_ci_diffprop'] = {
           );
           // Set default for link
           this.setFieldValue('"yes"', 'SUCCESS');
+          this.getInput('PROP_INPUT').appendField(')'); 
         } else if (newVar === 'racegrp') {
           this.getInput('PROP_INPUT').removeField('SUCCESS');
           this.getInput('PROP_INPUT').appendField(
@@ -81,6 +86,7 @@ Blockly.Blocks['bootstrap_ci_diffprop'] = {
           );
           // Set default for racegrp
           this.setFieldValue('"black"', 'SUCCESS');
+          this.getInput('PROP_INPUT').appendField(')'); 
         } else if (newVar === 'satreat') {
           this.getInput('PROP_INPUT').removeField('SUCCESS');
           this.getInput('PROP_INPUT').appendField(
@@ -92,6 +98,7 @@ Blockly.Blocks['bootstrap_ci_diffprop'] = {
           );
           // Set default for satreat
           this.setFieldValue('"yes"', 'SUCCESS');
+          this.getInput('PROP_INPUT').appendField(')'); 
         } else if (newVar === 'treat') {
           this.getInput('PROP_INPUT').removeField('SUCCESS');
           this.getInput('PROP_INPUT').appendField(
@@ -103,6 +110,7 @@ Blockly.Blocks['bootstrap_ci_diffprop'] = {
           );
           // Set default for treat
           this.setFieldValue('"yes"', 'SUCCESS');
+          this.getInput('PROP_INPUT').appendField(')'); 
         } else {
           this.getInput('PROP_INPUT').removeField('SUCCESS');
           this.getInput('PROP_INPUT').appendField(
@@ -112,6 +120,7 @@ Blockly.Blocks['bootstrap_ci_diffprop'] = {
             ]),
             'SUCCESS'
           );
+          this.getInput('PROP_INPUT').appendField(')'); 
         }
       }
       return newVar;
@@ -122,7 +131,7 @@ Blockly.Blocks['bootstrap_ci_diffprop'] = {
 
     this.appendDummyInput('PROP_INPUT')
       .appendField('prop_boot <- do(')
-      .appendField(new Blockly.FieldNumber(500, 10, 10000), 'ITERATIONS')
+      .appendField(new Blockly.FieldNumber(5000, 10, 10000), 'ITERATIONS')
       .appendField(') * diffprop(')
       .appendField(varField, 'VAR')
       .appendField(' ~ ')
@@ -135,7 +144,6 @@ Blockly.Blocks['bootstrap_ci_diffprop'] = {
         ]),
         'SUCCESS'
       )
-      .appendField(')');
     this.appendDummyInput()
       .appendField('confint(prop_boot, level = ')
       .appendField(new Blockly.FieldNumber(0.95, 0, 1, 0.01), 'CONF_LEVEL')
@@ -164,7 +172,7 @@ Blockly.Blocks['Gbootstrap_ci_diffprop'] = {
       .appendField(')');
     this.appendDummyInput()
       .appendField('prop_boot <- do(')
-      .appendField(new Blockly.FieldNumber(500, 10, 10000), 'ITERATIONS')
+      .appendField(new Blockly.FieldNumber(5000, 10, 10000), 'ITERATIONS')
       .appendField(') * diffprop(')
       .appendField(new Blockly.FieldTextInput(''), 'VAR')
       .appendField(' ~ ')

--- a/src/pages/modules/blockly/blocks/inference/bootstrap_ci_lm.js
+++ b/src/pages/modules/blockly/blocks/inference/bootstrap_ci_lm.js
@@ -10,7 +10,7 @@ Blockly.Blocks['bootstrap_ci_lm'] = {
       .appendField(')');
     this.appendDummyInput()
       .appendField('lm_boot <- do(')
-      .appendField(new Blockly.FieldNumber(500, 10, 10000), 'ITERATIONS')
+      .appendField(new Blockly.FieldNumber(5000, 10, 10000), 'ITERATIONS')
       .appendField(') * lm(')
       .appendField(new Blockly.FieldDropdown(quantitative_vars), 'VAR1')
       .appendField(' ~ ')
@@ -41,7 +41,7 @@ Blockly.Blocks['Gbootstrap_ci_lm'] = {
       .appendField(')');
     this.appendDummyInput()
       .appendField('lm_boot <- do(')
-      .appendField(new Blockly.FieldNumber(500, 10, 10000), 'ITERATIONS')
+      .appendField(new Blockly.FieldNumber(5000, 10, 10000), 'ITERATIONS')
       .appendField(') * lm(')
       .appendField(new Blockly.FieldTextInput(''), 'VAR1')
       .appendField(' ~ ')

--- a/src/pages/modules/blockly/blocks/inference/bootstrap_ci_mean.js
+++ b/src/pages/modules/blockly/blocks/inference/bootstrap_ci_mean.js
@@ -10,7 +10,7 @@ Blockly.Blocks['bootstrap_ci_mean'] = {
       .appendField(')');
     this.appendDummyInput()
       .appendField('mean_boot <- do(')
-      .appendField(new Blockly.FieldNumber(500, 10, 10000), 'ITERATIONS')
+      .appendField(new Blockly.FieldNumber(5000, 10, 10000), 'ITERATIONS')
       .appendField(') * mean(~')
       .appendField(new Blockly.FieldDropdown(quantitative_vars), 'VAR')
       .appendField(', data = resample(HELPrct))');

--- a/src/pages/modules/blockly/blocks/inference/bootstrap_ci_paired.js
+++ b/src/pages/modules/blockly/blocks/inference/bootstrap_ci_paired.js
@@ -16,13 +16,14 @@ Blockly.Blocks['bootstrap_ci_paired'] = {
       .appendField(')');
     this.appendDummyInput()
       .appendField('mean_boot <- do(')
-      .appendField(new Blockly.FieldNumber(500, 10, 10000), 'ITERATIONS')
-      .appendField(') * mean(~ pair.diff, data = resample(HELPrct))');
+      .appendField(new Blockly.FieldNumber(5000, 10, 10000), 'ITERATIONS')
+      .appendField(') *');
+    this.appendDummyInput()
+      .appendField('    mean(~ pair.diff, data = resample(HELPrct))');
     this.appendDummyInput()
       .appendField('confint(mean_boot, level = ')
       .appendField(new Blockly.FieldNumber(0.95, 0, 1, 0.01), 'CONF_LEVEL')
       .appendField(', method = "quantile")');
-
     this.setInputsInline(false);
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
@@ -51,7 +52,7 @@ Blockly.Blocks['Gbootstrap_ci_paired'] = {
       .appendField(')');
     this.appendDummyInput()
       .appendField('mean_boot <- do(')
-      .appendField(new Blockly.FieldNumber(500, 10, 10000), 'ITERATIONS')
+      .appendField(new Blockly.FieldNumber(5000, 10, 10000), 'ITERATIONS')
       .appendField(') * mean(~ pair.diff, data = resample(')
       .appendField(new Blockly.FieldTextInput(''), 'RESAMPLE_DATASET')
       .appendField('))');

--- a/src/pages/modules/blockly/blocks/inference/bootstrap_ci_prop.js
+++ b/src/pages/modules/blockly/blocks/inference/bootstrap_ci_prop.js
@@ -24,6 +24,7 @@ Blockly.Blocks['bootstrap_ci_prop'] = {
             ]),
             'SUCCESS'
           );
+          this.getInput('PROP_INPUT').appendField(')'); 
         } else if (newVar === 'anysub') {
           this.getInput('PROP_INPUT').removeField('SUCCESS');
           this.getInput('PROP_INPUT').appendField(
@@ -35,6 +36,7 @@ Blockly.Blocks['bootstrap_ci_prop'] = {
           );
           // Set default for anysub
           this.setFieldValue('"yes"', 'SUCCESS');
+          this.getInput('PROP_INPUT').appendField(')'); 
         } else if (newVar === 'sex') {
           this.getInput('PROP_INPUT').removeField('SUCCESS');
           this.getInput('PROP_INPUT').appendField(
@@ -46,6 +48,7 @@ Blockly.Blocks['bootstrap_ci_prop'] = {
           );
           // Set default for sex
           this.setFieldValue('"male"', 'SUCCESS');
+          this.getInput('PROP_INPUT').appendField(')'); 
         } else if (newVar === 'homeless') {
           this.getInput('PROP_INPUT').removeField('SUCCESS');
           this.getInput('PROP_INPUT').appendField(
@@ -57,6 +60,7 @@ Blockly.Blocks['bootstrap_ci_prop'] = {
           );
           // Set default for homeless
           this.setFieldValue('"homeless"', 'SUCCESS');
+          this.getInput('PROP_INPUT').appendField(')'); 
         } else if (newVar === 'link') {
           this.getInput('PROP_INPUT').removeField('SUCCESS');
           this.getInput('PROP_INPUT').appendField(
@@ -68,6 +72,7 @@ Blockly.Blocks['bootstrap_ci_prop'] = {
           );
           // Set default for link
           this.setFieldValue('"yes"', 'SUCCESS');
+          this.getInput('PROP_INPUT').appendField(')'); 
         } else if (newVar === 'racegrp') {
           this.getInput('PROP_INPUT').removeField('SUCCESS');
           this.getInput('PROP_INPUT').appendField(
@@ -81,6 +86,7 @@ Blockly.Blocks['bootstrap_ci_prop'] = {
           );
           // Set default for racegrp
           this.setFieldValue('"black"', 'SUCCESS');
+          this.getInput('PROP_INPUT').appendField(')'); 
         } else if (newVar === 'satreat') {
           this.getInput('PROP_INPUT').removeField('SUCCESS');
           this.getInput('PROP_INPUT').appendField(
@@ -92,6 +98,7 @@ Blockly.Blocks['bootstrap_ci_prop'] = {
           );
           // Set default for satreat
           this.setFieldValue('"yes"', 'SUCCESS');
+          this.getInput('PROP_INPUT').appendField(')'); 
         } else if (newVar === 'treat') {
           this.getInput('PROP_INPUT').removeField('SUCCESS');
           this.getInput('PROP_INPUT').appendField(
@@ -103,6 +110,7 @@ Blockly.Blocks['bootstrap_ci_prop'] = {
           );
           // Set default for treat
           this.setFieldValue('"yes"', 'SUCCESS');
+          this.getInput('PROP_INPUT').appendField(')'); 
         } else {
           this.getInput('PROP_INPUT').removeField('SUCCESS');
           this.getInput('PROP_INPUT').appendField(
@@ -112,6 +120,7 @@ Blockly.Blocks['bootstrap_ci_prop'] = {
             ]),
             'SUCCESS'
           );
+          this.getInput('PROP_INPUT').appendField(')'); 
         }
       }
       return newVar;
@@ -119,7 +128,7 @@ Blockly.Blocks['bootstrap_ci_prop'] = {
 
     this.appendDummyInput('PROP_INPUT')
       .appendField('boot <- do(')
-      .appendField(new Blockly.FieldNumber(500, 10, 10000), 'ITERATIONS')
+      .appendField(new Blockly.FieldNumber(5000, 10, 10000), 'ITERATIONS')
       .appendField(') * prop(~')
       .appendField(varField, 'VAR')
       .appendField(', data = resample(HELPrct), success = ')
@@ -131,7 +140,6 @@ Blockly.Blocks['bootstrap_ci_prop'] = {
         ]),
         'SUCCESS'
       )
-      .appendField(')');
     this.appendDummyInput()
       .appendField('confint(boot, level = ')
       .appendField(new Blockly.FieldNumber(0.95, 0, 1, 0.01), 'CONF_LEVEL')
@@ -158,7 +166,7 @@ Blockly.Blocks['Gbootstrap_ci_prop'] = {
       .appendField(')');
     this.appendDummyInput()
       .appendField('boot <- do(')
-      .appendField(new Blockly.FieldNumber(500, 10, 10000), 'ITERATIONS')
+      .appendField(new Blockly.FieldNumber(5000, 10, 10000), 'ITERATIONS')
       .appendField(') * prop(~')
       .appendField(new Blockly.FieldTextInput(''), 'VAR')
       .appendField(', data = resample(')

--- a/src/pages/modules/blockly/blocks/inference/bootstrap_test_mean.js
+++ b/src/pages/modules/blockly/blocks/inference/bootstrap_test_mean.js
@@ -20,7 +20,7 @@ Blockly.Blocks['bootstrap_test_mean'] = {
       .appendField(' - observed_mean)');
     this.appendDummyInput()
       .appendField('sim_null <- do(')
-      .appendField(new Blockly.FieldNumber(500, 10, 10000), 'ITERATIONS')
+      .appendField(new Blockly.FieldNumber(5000, 10, 10000), 'ITERATIONS')
       .appendField(') * mean(~ new_')
       .appendField(new Blockly.FieldDropdown(quantitative_vars), 'VAR4')
       .appendField(', data = resample(HELPrct_shifted))');
@@ -83,7 +83,7 @@ Blockly.Blocks['Gbootstrap_test_mean'] = {
       .appendField(' - observed_mean)');
     this.appendDummyInput()
       .appendField('sim_null <- do(')
-      .appendField(new Blockly.FieldNumber(500, 10, 10000), 'ITERATIONS')
+      .appendField(new Blockly.FieldNumber(5000, 10, 10000), 'ITERATIONS')
       .appendField(') * mean(~ new_')
       .appendField(new Blockly.FieldTextInput(''), 'VAR4')
       .appendField(', data = resample(')

--- a/src/pages/modules/blockly/blocks/inference/bootstrap_test_paired.js
+++ b/src/pages/modules/blockly/blocks/inference/bootstrap_test_paired.js
@@ -18,8 +18,10 @@ Blockly.Blocks['bootstrap_test_paired'] = {
     this.appendDummyInput().appendField('HELPrct <- mutate(HELPrct, new_diff = pair.diff - bar_d)');
     this.appendDummyInput()
       .appendField('sim_null <- do(')
-      .appendField(new Blockly.FieldNumber(500, 10, 10000), 'ITERATIONS')
-      .appendField(') * mean(~ new_diff, data = resample(HELPrct))');
+      .appendField(new Blockly.FieldNumber(5000, 10, 10000), 'ITERATIONS')
+      .appendField(') *');
+    this.appendDummyInput()
+      .appendField('    mean(~ new_diff, data = resample(HELPrct))');
     this.appendDummyInput()
       .appendField('prop(~ (')
       .appendField(
@@ -70,7 +72,7 @@ Blockly.Blocks['Gbootstrap_test_paired'] = {
       .appendField(', new_diff = pair.diff - bar_d)');
     this.appendDummyInput()
       .appendField('sim_null <- do(')
-      .appendField(new Blockly.FieldNumber(500, 10, 10000), 'ITERATIONS')
+      .appendField(new Blockly.FieldNumber(5000, 10, 10000), 'ITERATIONS')
       .appendField(') * mean(~ new_diff, data = resample(')
       .appendField(new Blockly.FieldTextInput(''), 'RESAMPLE_DATASET')
       .appendField('))');

--- a/src/pages/modules/blockly/blocks/inference/bootstrap_test_prop.js
+++ b/src/pages/modules/blockly/blocks/inference/bootstrap_test_prop.js
@@ -24,6 +24,7 @@ Blockly.Blocks['bootstrap_test_prop'] = {
             ]),
             'SUCCESS'
           );
+          this.getInput('PROP_INPUT').appendField(')'); 
         } else if (newVar === 'anysub') {
           this.getInput('PROP_INPUT').removeField('SUCCESS');
           this.getInput('PROP_INPUT').appendField(
@@ -35,6 +36,7 @@ Blockly.Blocks['bootstrap_test_prop'] = {
           );
           // Set default for anysub
           this.setFieldValue('"yes"', 'SUCCESS');
+          this.getInput('PROP_INPUT').appendField(')'); 
         } else if (newVar === 'sex') {
           this.getInput('PROP_INPUT').removeField('SUCCESS');
           this.getInput('PROP_INPUT').appendField(
@@ -46,6 +48,7 @@ Blockly.Blocks['bootstrap_test_prop'] = {
           );
           // Set default for sex
           this.setFieldValue('"male"', 'SUCCESS');
+          this.getInput('PROP_INPUT').appendField(')'); 
         } else if (newVar === 'homeless') {
           this.getInput('PROP_INPUT').removeField('SUCCESS');
           this.getInput('PROP_INPUT').appendField(
@@ -57,6 +60,7 @@ Blockly.Blocks['bootstrap_test_prop'] = {
           );
           // Set default for homeless
           this.setFieldValue('"homeless"', 'SUCCESS');
+          this.getInput('PROP_INPUT').appendField(')'); 
         } else if (newVar === 'link') {
           this.getInput('PROP_INPUT').removeField('SUCCESS');
           this.getInput('PROP_INPUT').appendField(
@@ -68,6 +72,7 @@ Blockly.Blocks['bootstrap_test_prop'] = {
           );
           // Set default for link
           this.setFieldValue('"yes"', 'SUCCESS');
+          this.getInput('PROP_INPUT').appendField(')'); 
         } else if (newVar === 'racegrp') {
           this.getInput('PROP_INPUT').removeField('SUCCESS');
           this.getInput('PROP_INPUT').appendField(
@@ -81,6 +86,7 @@ Blockly.Blocks['bootstrap_test_prop'] = {
           );
           // Set default for racegrp
           this.setFieldValue('"black"', 'SUCCESS');
+          this.getInput('PROP_INPUT').appendField(')'); 
         } else if (newVar === 'satreat') {
           this.getInput('PROP_INPUT').removeField('SUCCESS');
           this.getInput('PROP_INPUT').appendField(
@@ -92,6 +98,7 @@ Blockly.Blocks['bootstrap_test_prop'] = {
           );
           // Set default for satreat
           this.setFieldValue('"yes"', 'SUCCESS');
+          this.getInput('PROP_INPUT').appendField(')'); 
         } else if (newVar === 'treat') {
           this.getInput('PROP_INPUT').removeField('SUCCESS');
           this.getInput('PROP_INPUT').appendField(
@@ -103,6 +110,7 @@ Blockly.Blocks['bootstrap_test_prop'] = {
           );
           // Set default for treat
           this.setFieldValue('"yes"', 'SUCCESS');
+          this.getInput('PROP_INPUT').appendField(')'); 
         } else {
           this.getInput('PROP_INPUT').removeField('SUCCESS');
           this.getInput('PROP_INPUT').appendField(
@@ -112,6 +120,7 @@ Blockly.Blocks['bootstrap_test_prop'] = {
             ]),
             'SUCCESS'
           );
+          this.getInput('PROP_INPUT').appendField(')'); 
         }
       }
       return newVar;
@@ -130,11 +139,10 @@ Blockly.Blocks['bootstrap_test_prop'] = {
       ]),
       'SUCCESS'
     );
-    propInput.appendField(')');
 
     this.appendDummyInput()
       .appendField('sim_null <- do(')
-      .appendField(new Blockly.FieldNumber(500, 10, 10000), 'ITERATIONS')
+      .appendField(new Blockly.FieldNumber(5000, 10, 10000), 'ITERATIONS')
       .appendField(') * rflip(n=')
       .appendField(new Blockly.FieldNumber(100, 1), 'SAMPLE_SIZE')
       .appendField(', prob=')
@@ -182,7 +190,7 @@ Blockly.Blocks['Gbootstrap_test_prop'] = {
       .appendField(')');
     this.appendDummyInput()
       .appendField('sim_null <- do(')
-      .appendField(new Blockly.FieldNumber(500, 10, 10000), 'ITERATIONS')
+      .appendField(new Blockly.FieldNumber(5000, 10, 10000), 'ITERATIONS')
       .appendField(') * rflip(n=')
       .appendField(new Blockly.FieldNumber(100, 1), 'SAMPLE_SIZE')
       .appendField(', prob=')


### PR DESCRIPTION
This pull request includes several changes to the `src/pages/modules/blockly/blocks/inference` directory, focusing on updating the number of iterations for various statistical functions and ensuring proper field appendages in the `PROP_INPUT` blocks.

### Iteration Updates:
* Updated the number of iterations from 500 to 5000 in the following files:
  - `bootstrap_ci_cor.js`
  - `bootstrap_ci_diffmean.js` [[1]](diffhunk://#diff-3b9e746b19d49b75466e24298df3052095d795a7df1721b2cec961c62881a617L13-R13) [[2]](diffhunk://#diff-3b9e746b19d49b75466e24298df3052095d795a7df1721b2cec961c62881a617L42-R42)
  - `bootstrap_ci_diffprop.js` [[1]](diffhunk://#diff-7b44a3e5e5c7083765558b6e5e94b8c2556c5eb22be75476791149b54a9bf92aL125-R134) [[2]](diffhunk://#diff-7b44a3e5e5c7083765558b6e5e94b8c2556c5eb22be75476791149b54a9bf92aL167-R175)
  - `bootstrap_ci_lm.js` [[1]](diffhunk://#diff-9ae1d07073bd2b54b46bb418949f288f57a00457b1f3db6e62b1b430a29596eaL13-R13) [[2]](diffhunk://#diff-9ae1d07073bd2b54b46bb418949f288f57a00457b1f3db6e62b1b430a29596eaL44-R44)
  - `bootstrap_ci_mean.js`
  - `bootstrap_ci_paired.js` [[1]](diffhunk://#diff-1b19380be58aab6c8b11e5658475ebd0acc0cae3dfbedab43deb7960d14ea1ccL19-L25) [[2]](diffhunk://#diff-1b19380be58aab6c8b11e5658475ebd0acc0cae3dfbedab43deb7960d14ea1ccL54-R55)
  - `bootstrap_ci_prop.js` [[1]](diffhunk://#diff-a28d8025507a9ebe87a300003d2db274eca3d3fecb794d8dffd1f9903660fb01R123-R131) [[2]](diffhunk://#diff-a28d8025507a9ebe87a300003d2db274eca3d3fecb794d8dffd1f9903660fb01L161-R169)
  - `bootstrap_test_mean.js`

### Field Appendage Fixes:
* Added missing `)` to `PROP_INPUT` fields in `bootstrap_ci_diffprop.js` [[1]](diffhunk://#diff-7b44a3e5e5c7083765558b6e5e94b8c2556c5eb22be75476791149b54a9bf92aR27) [[2]](diffhunk://#diff-7b44a3e5e5c7083765558b6e5e94b8c2556c5eb22be75476791149b54a9bf92aR39) [[3]](diffhunk://#diff-7b44a3e5e5c7083765558b6e5e94b8c2556c5eb22be75476791149b54a9bf92aR51) [[4]](diffhunk://#diff-7b44a3e5e5c7083765558b6e5e94b8c2556c5eb22be75476791149b54a9bf92aR63) [[5]](diffhunk://#diff-7b44a3e5e5c7083765558b6e5e94b8c2556c5eb22be75476791149b54a9bf92aR75) [[6]](diffhunk://#diff-7b44a3e5e5c7083765558b6e5e94b8c2556c5eb22be75476791149b54a9bf92aR89) [[7]](diffhunk://#diff-7b44a3e5e5c7083765558b6e5e94b8c2556c5eb22be75476791149b54a9bf92aR101) [[8]](diffhunk://#diff-7b44a3e5e5c7083765558b6e5e94b8c2556c5eb22be75476791149b54a9bf92aR113) [[9]](diffhunk://#diff-7b44a3e5e5c7083765558b6e5e94b8c2556c5eb22be75476791149b54a9bf92aR123)
* Added missing `)` to `PROP_INPUT` fields in `bootstrap_ci_prop.js` [[1]](diffhunk://#diff-a28d8025507a9ebe87a300003d2db274eca3d3fecb794d8dffd1f9903660fb01R27) [[2]](diffhunk://#diff-a28d8025507a9ebe87a300003d2db274eca3d3fecb794d8dffd1f9903660fb01R39) [[3]](diffhunk://#diff-a28d8025507a9ebe87a300003d2db274eca3d3fecb794d8dffd1f9903660fb01R51) [[4]](diffhunk://#diff-a28d8025507a9ebe87a300003d2db274eca3d3fecb794d8dffd1f9903660fb01R63) [[5]](diffhunk://#diff-a28d8025507a9ebe87a300003d2db274eca3d3fecb794d8dffd1f9903660fb01R75) [[6]](diffhunk://#diff-a28d8025507a9ebe87a300003d2db274eca3d3fecb794d8dffd1f9903660fb01R89) [[7]](diffhunk://#diff-a28d8025507a9ebe87a300003d2db274eca3d3fecb794d8dffd1f9903660fb01R101) [[8]](diffhunk://#diff-a28d8025507a9ebe87a300003d2db274eca3d3fecb794d8dffd1f9903660fb01R113) [[9]](diffhunk://#diff-a28d8025507a9ebe87a300003d2db274eca3d3fecb794d8dffd1f9903660fb01R123-R131)